### PR TITLE
ci: add pr-monitor as the CI Gate

### DIFF
--- a/.github/workflows/pr-monitor.yml
+++ b/.github/workflows/pr-monitor.yml
@@ -1,0 +1,24 @@
+name: PR Monitor
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+
+jobs:
+  monitor:
+    name: 'CI Gate'
+    runs-on: ubuntu-latest
+    # The action has no timeout of its own (see monitor.ts) — this is the
+    # backstop. If a predicted run never dispatches, the gate waits here
+    # until the job is killed.
+    timeout-minutes: 45
+    steps:
+      - uses: thekevinscott/pr-monitor@v1


### PR DESCRIPTION
Adds pr-monitor as the aggregate `CI Gate` check, matching the fleet standard.

The three inputs dirsql passes (`minimum-checks`, `pre-sleep`, `timeout`) are
omitted: `action.yml` declares only `github-token`, and `src/` reads only
`process.env.GITHUB_TOKEN`, so they are inert. The intended ceiling is expressed
as a real `timeout-minutes`, which `monitor.ts` names as the only backstop.
`pull-requests: read` is included because `action.yml` documents it as required;
it works without it today only because these repos are public.